### PR TITLE
Update using_app_editor.md

### DIFF
--- a/doc/howtos/using_app_editor/using_app_editor.md
+++ b/doc/howtos/using_app_editor/using_app_editor.md
@@ -16,7 +16,7 @@ See the ZEISS Quality Tech Guide article [App Editor](https://techguide.zeiss.co
   * [Inserting a File Selection Dialog](#inserting-a-file-selection-dialog)
 - [Adding and Removing Contents](#adding-moving-and-copying-contents)
 - [Searching and Filtering](#searching-and-filtering)
-- [Exporting or Publishing an App](#exporting-or-publishing-an-app)
+- [Exporting an App](#exporting-an-app)
 - [Apps from External Folders](#apps-from-external-folders)
   * [Connecting and Disconnecting External Folders](#connecting-and-disconnecting-external-folders)
   * [Creating Apps in External Folders](#creating-apps-in-external-folders)
@@ -128,19 +128,11 @@ A project must be opened to provide items in the Project Contents section. An Ap
 
 To ease working with a large number of installed Apps, searching and filtering can be used. The search function allows to enter parts of a file name. The search keyword can then be applied as a filter. An additional function allows to filter by storage location and content type.
 
-## Exporting or Publishing an App
+## Exporting an App
 
 * Export
 
     Click RMB on the installed App ► Export: Save the selected App as a .addon file.
-
-* Publish in Software Store
-
-    Click RMB on the installed App ► Publish in Software Store: Upload the selected App into the Zeiss Quality Software Store. The uploaded App will be queued into the staging area and will be release after approval.
-    
-    ```{note}
-    Publishing an App requires special permission that ZEISS grants upon request.
-    ```
 
 ## Apps from External Folders
 

--- a/doc/howtos/using_app_editor/using_app_editor.md
+++ b/doc/howtos/using_app_editor/using_app_editor.md
@@ -130,9 +130,7 @@ To ease working with a large number of installed Apps, searching and filtering c
 
 ## Exporting an App
 
-* Export
-
-    Click RMB on the installed App ► Export: Save the selected App as a .addon file.
+Click RMB on the installed App ► Export: Save the selected App as a .addon file.
 
 ## Apps from External Folders
 


### PR DESCRIPTION
https://iqs-jira.zeiss.org/browse/AD-1109
Removed documentation of publishing an App in the software store from https://zeissiqs.github.io/zeiss-inspect-addon-api/2025/howtos/using_app_editor/using_app_editor.html, because this feature in no longer available in SW2025.