### PR TITLE
Update localization.md

### DIFF
--- a/doc/howtos/localization/localization.md
+++ b/doc/howtos/localization/localization.md
@@ -35,8 +35,12 @@ DIALOG=gom.script.sys.create_user_defined_dialog (dialog={
 
 Texts in scripts have to be tagged as translatable via using the `tr ()`  function. During translation file generation, these texts will be processed and later replaced at runtime with the available translations.
 
-    print (tr ('This text will be translated'))
+``` Python
+import gom
+from gom import tr
 
+print (tr ('This text will be translated'))
+```
 
 ## Translating scripts
 


### PR DESCRIPTION
https://iqs-jira.zeiss.org/browse/AD-1117

Note:
 
In ZEISS INSPECT 2023, `tr()` is automatically imported with `import gom`. However, the explicit
```
from gom import tr
```
does not harm either and makes the code compatible to ZEISS INSPECT 2025.